### PR TITLE
Removed unnecessary and conflicting pin inits

### DIFF
--- a/TFT_HX8357_Due.cpp
+++ b/TFT_HX8357_Due.cpp
@@ -251,17 +251,6 @@ void TFT_HX8357_Due::init(void)
 
   pinMode(_fcs, OUTPUT);
   digitalWrite(_fcs, HIGH); // Stop line floating
-  pinMode(A0, OUTPUT);
-  digitalWrite(A0, HIGH);
-
-  pinMode(8, OUTPUT);
-  pinMode(9, OUTPUT);
-  pinMode(2, OUTPUT);
-  pinMode(3, OUTPUT);
-  pinMode(4, OUTPUT);
-  pinMode(5, OUTPUT);
-  pinMode(6, OUTPUT);
-  pinMode(7, OUTPUT);
 
   // toggle RST low to reset
     digitalWrite(_rst, HIGH);


### PR DESCRIPTION
Apparently this part was leftovers from the adafruit library. It just caused the library to mess up with pin modes on pins it doesn't actually use since all of the pin initialization is done correctly in the constructor.