### PR TITLE
Use a single tab field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -1,83 +1,83 @@
-TFT_HX8357_Due		KEYWORD1
+TFT_HX8357_Due	KEYWORD1
 
-init				KEYWORD2
-drawPixel			KEYWORD2
+init	KEYWORD2
+drawPixel	KEYWORD2
 
-drawChar			KEYWORD2
-setWindow			KEYWORD2
+drawChar	KEYWORD2
+setWindow	KEYWORD2
 
-pushColor			KEYWORD2
-pushColor			KEYWORD2
+pushColor	KEYWORD2
+pushColor	KEYWORD2
 
-pushColors			KEYWORD2
-pushColors			KEYWORD2
+pushColors	KEYWORD2
+pushColors	KEYWORD2
 
-fillScreen			KEYWORD2
+fillScreen	KEYWORD2
 
-drawLine			KEYWORD2
-drawFastVLine		KEYWORD2
-drawFastHLine		KEYWORD2
+drawLine	KEYWORD2
+drawFastVLine	KEYWORD2
+drawFastHLine	KEYWORD2
 
-drawRect			KEYWORD2
-fillRect			KEYWORD2
-drawRoundRect		KEYWORD2
-fillRoundRect		KEYWORD2
+drawRect	KEYWORD2
+fillRect	KEYWORD2
+drawRoundRect	KEYWORD2
+fillRoundRect	KEYWORD2
 
-setRotation		KEYWORD2
-invertDisplay		KEYWORD2
+setRotation	KEYWORD2
+invertDisplay	KEYWORD2
 
-drawCircle			KEYWORD2
+drawCircle	KEYWORD2
 drawCircleHelper	KEYWORD2
 fillCircle	KEYWORD2
 fillCircleHelper	KEYWORD2
 
-drawEllipse		KEYWORD2
-fillEllipse		KEYWORD2
+drawEllipse	KEYWORD2
+fillEllipse	KEYWORD2
 
-drawTriangle		KEYWORD2
-fillTriangle		KEYWORD2
+drawTriangle	KEYWORD2
+fillTriangle	KEYWORD2
 
-drawBitmap			KEYWORD2
+drawBitmap	KEYWORD2
 
-setCursor			KEYWORD2
-setCursor			KEYWORD2
-setTextColor		KEYWORD2
-setTextSize		KEYWORD2
-setTextFont		KEYWORD2
-setTextWrap		KEYWORD2
-setTextDatum		KEYWORD2
-setTextPadding		KEYWORD2
+setCursor	KEYWORD2
+setCursor	KEYWORD2
+setTextColor	KEYWORD2
+setTextSize	KEYWORD2
+setTextFont	KEYWORD2
+setTextWrap	KEYWORD2
+setTextDatum	KEYWORD2
+setTextPadding	KEYWORD2
 
-setFreeFont		KEYWORD2
+setFreeFont	KEYWORD2
 
-writecommand		KEYWORD2
-writedata			KEYWORD2
-fgColor			KEYWORD2
-bgColor			KEYWORD2
-fgWrite			KEYWORD2
-bgWrite			KEYWORD2
-addrCmd			KEYWORD2
-commandList		KEYWORD2
+writecommand	KEYWORD2
+writedata	KEYWORD2
+fgColor	KEYWORD2
+bgColor	KEYWORD2
+fgWrite	KEYWORD2
+bgWrite	KEYWORD2
+addrCmd	KEYWORD2
+commandList	KEYWORD2
 
-getRotation		KEYWORD2
+getRotation	KEYWORD2
 
-fontsLoaded		KEYWORD2
-color565			KEYWORD2
+fontsLoaded	KEYWORD2
+color565	KEYWORD2
 
-drawChar			KEYWORD2
-drawNumber			KEYWORD2
-drawFloat			KEYWORD2
+drawChar	KEYWORD2
+drawNumber	KEYWORD2
+drawFloat	KEYWORD2
 
-drawString			KEYWORD2
+drawString	KEYWORD2
 drawCentreString	KEYWORD2
-drawRightString		KEYWORD2
+drawRightString	KEYWORD2
 
-height			KEYWORD2
-width				KEYWORD2
-textWidth			KEYWORD2
-fontHeight			KEYWORD2
+height	KEYWORD2
+width	KEYWORD2
+textWidth	KEYWORD2
+fontHeight	KEYWORD2
 
-setWindow			KEYWORD2
-hi_byte			KEYWORD2
-lo_byte			KEYWORD2
+setWindow	KEYWORD2
+hi_byte	KEYWORD2
+lo_byte	KEYWORD2
 


### PR DESCRIPTION
Each field of keywords.txt is separated by a single true tab. When you use multiple tabs it causes the field to be interpreted as empty. On Arduino IDE 1.6.5 and newer an empty KEYWORD_TOKENTYPE causes the default editor.function.style coloration to be used (as with KEYWORD2, KEYWORD3, LITERAL2). On Arduino IDE 1.6.4 and older it causes the keyword to not be recognized for any special coloration.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords